### PR TITLE
ci: use Temurin JDK 23 to match pom (release 23)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up JDK 
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '23'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
`pom.xml` bruker `maven.compiler.release=23`, mens GitHub Actions bygget på JDK 21. 
Denne PR-en oppdaterer workflowen til JDK 23 for å unngå `error: release version 23 not supported`.

Endringer:
- .github/workflows/maven.yml: `java-version: '23'`